### PR TITLE
Remove warning on name being shadowed

### DIFF
--- a/boot.properties
+++ b/boot.properties
@@ -1,4 +1,3 @@
 #https://github.com/boot-clj/boot
-#Sat Feb 28 15:49:24 CET 2015
-BOOT_CLOJURE_VERSION=1.7.0-alpha5
-BOOT_VERSION=2.0.0-rc10
+BOOT_CLOJURE_VERSION=1.7.0
+BOOT_VERSION=2.4.2

--- a/src/clj/ewen/boot/boot_maven.clj
+++ b/src/clj/ewen/boot/boot_maven.clj
@@ -5,6 +5,7 @@
             [boot.core :as core :refer [deftask get-env]]
             [boot.util :as util]
             [boot.pod :as pod])
+  (:refer-clojure :exclude [name])
   (:import (java.util Properties)))
 
 (xml/decelems


### PR DESCRIPTION
Avoids `WARNING: name already refers to: #'clojure.core/name in namespace: ewen.boot.boot-maven, being replaced by: #'ewen.boot.boot-maven/name`.
